### PR TITLE
Fixed issue with account switching

### DIFF
--- a/php/src/Objects/Account/Account.php
+++ b/php/src/Objects/Account/Account.php
@@ -3,6 +3,7 @@
 
 namespace Kinicart\Objects\Account;
 
+use Kiniauth\Attributes\Security\AccessNonActiveScopes;
 use Kiniauth\Objects\Security\AccountRole;
 
 /**
@@ -10,6 +11,7 @@ use Kiniauth\Objects\Security\AccountRole;
  *
  * @table ka_account
  */
+#[AccessNonActiveScopes]
 class Account extends \Kiniauth\Objects\Account\Account {
 
     /**


### PR DESCRIPTION
One liner to ensure that Kinicart Account extensions are permitted for cross account access for when we switch account etc.